### PR TITLE
todo_list, todo_list_detail, remembrance 페이지 수정

### DIFF
--- a/src/main/java/com/todorank/hlw/domain/home/MainController.java
+++ b/src/main/java/com/todorank/hlw/domain/home/MainController.java
@@ -9,4 +9,68 @@ public class MainController {
     public String root() {
         return "login_after";
     }
+
+    @GetMapping("/login_before")
+    public String root1() {
+        return "login_before";
+    }
+
+    @GetMapping("/login")
+    public String root2() {
+        return "login_page";
+    }
+
+    @GetMapping("/navbar")
+    public String root3() {
+        return "navbar";
+    }
+
+    @GetMapping("/profile_modify")
+    public String root4() {
+        return "profile_modify_page";
+    }
+
+    @GetMapping("/profile_read")
+    public String root5() {
+        return "profile_read_page";
+    }
+
+    @GetMapping("/rankings_list")
+    public String root6() {
+        return "rankings_list_page";
+    }
+
+    @GetMapping("/remembrance")
+    public String root7() {
+        return "remembrance_page";
+    }
+
+    @GetMapping("/retrospective_from")
+    public String root8() {
+        return "retrospective_from_page";
+    }
+
+    //500에러
+    @GetMapping("/signup")
+    public String root9() {
+        return "signup_page";
+    }
+
+    @GetMapping("/todo_card_read_create")
+    public String root10() {
+        return "todo_card_read_create_page";
+    }
+
+    //500 에러
+    @GetMapping("/todo_list")
+    public String root11() {
+        return "todo_list";
+    }
+
+    //수정할 것(페이징)
+    @GetMapping("/todo_list_detail")
+    public String root12() {
+        return "todo_list_detail";
+    }
+
 }

--- a/src/main/java/com/todorank/hlw/domain/home/MainController.java
+++ b/src/main/java/com/todorank/hlw/domain/home/MainController.java
@@ -61,7 +61,7 @@ public class MainController {
         return "todo_card_read_create_page";
     }
 
-    //500 에러
+    // URL 경로로 직접 접근시 500 에러(루트경로에서 접근할 것)
     @GetMapping("/todo_list")
     public String root11() {
         return "todo_list";

--- a/src/main/java/com/todorank/hlw/domain/user/controller/UserController.java
+++ b/src/main/java/com/todorank/hlw/domain/user/controller/UserController.java
@@ -36,7 +36,7 @@ public class UserController {
                     userCreateForm.getEmail(), userCreateForm.getNickname());
         } catch (DataIntegrityViolationException e) {
             e.printStackTrace();
-            bindingResult.reject("signup error", "이미 가입된 아이디 혹은 이메일입니다.");
+            bindingResult.reject("signup_page error", "이미 가입된 아이디 혹은 이메일입니다.");
             return "signup_page";
         }
         return "login_after";

--- a/src/main/resources/static/rankings_list_page.css
+++ b/src/main/resources/static/rankings_list_page.css
@@ -100,7 +100,7 @@ body {
 
 .pagination {
     margin: 20px 0;
-    font-size: 16px;
+    font-size: 20px;
 }
 
 .pagination a {

--- a/src/main/resources/static/remembrance.css
+++ b/src/main/resources/static/remembrance.css
@@ -85,19 +85,26 @@ body {
 }
 
 .review-content h2 {
+    margin-left: 20px;
     font-size: 18px;
     border-bottom: 2px solid #333;
     display: inline-block;
     padding-bottom: 5px;
 }
 
+h2 {
+    margin-top: 50px;
+}
+
 .review-content .visibility {
+    margin-top: 15px;
     float: right;
     font-size: 14px;
     color: #666;
 }
 
 .review-content p {
+    padding: 20px;
     margin: 20px 0;
     font-size: 16px;
     color: #666;
@@ -139,14 +146,16 @@ body {
 }
 
 textarea {
-    width: 100%; /* 부모 너비에 맞게 확장 */
+    width: 100%;
     height: 60px;
     padding: 10px;
     margin-top: 10px;
     border-radius: 5px;
     border: 1px solid #ddd;
     resize: none;
+    box-sizing: border-box; /* padding과 border를 포함하여 너비를 맞추도록 설정 */
 }
+
 
 .submit-comment {
     display: block;

--- a/src/main/resources/static/remembrance.css
+++ b/src/main/resources/static/remembrance.css
@@ -40,7 +40,7 @@ body {
 }
 
 .search-box input[type="text"] {
-    padding: 5px 35px 5px 15px;
+    padding: 5px 30px 5px 10px;
     border-radius: 20px;
     border: 1px solid #ddd;
 }
@@ -68,7 +68,7 @@ body {
     color: #fff;
     text-align: center;
     padding: 15px 0;
-    border-radius: 8px 8px 0 0; /* 상단 모서리만 둥글게 */
+    border-radius: 8px;
 }
 
 .highlight-section h1 {
@@ -79,12 +79,9 @@ body {
 
 .review-container {
     background-color: #fff;
+    padding: 20px;
     border-radius: 8px;
     box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
-}
-
-.review-content {
-    padding: 20px;
 }
 
 .review-content h2 {
@@ -134,12 +131,6 @@ body {
     margin-bottom: 5px;
 }
 
-.comment p {
-    margin: 10px 0;
-    color: #555;
-    font-size: 16px;
-}
-
 .comment-info {
     display: flex;
     justify-content: flex-end;
@@ -149,7 +140,6 @@ body {
 
 textarea {
     width: 100%; /* 부모 너비에 맞게 확장 */
-    box-sizing: border-box; /* 패딩이 너비에 포함되도록 설정 */
     height: 60px;
     padding: 10px;
     margin-top: 10px;
@@ -160,14 +150,13 @@ textarea {
 
 .submit-comment {
     display: block;
-    width: 150px; /* 버튼의 너비를 축소 */
-    box-sizing: border-box; /* 패딩 포함 */
+    width: 100%;
     padding: 10px;
     background-color: #333;
     color: #fff;
     border: none;
     border-radius: 5px;
-    margin: 10px auto 0; /* 상단 여백과 가운데 정렬 */
+    margin-top: 10px;
     cursor: pointer;
 }
 
@@ -179,7 +168,7 @@ textarea {
 
 .pagination a, .pagination span {
     color: #333;
-    margin: 0 5px;
+    margin: 0 50px;
     text-decoration: none;
 }
 

--- a/src/main/resources/static/retrospective_from_page.css
+++ b/src/main/resources/static/retrospective_from_page.css
@@ -1,307 +1,133 @@
-.div,
-.div * {
-  box-sizing: border-box;
+* {
+    box-sizing: border-box;
+    margin: 0;
+    padding: 0;
+    font-family: Arial, sans-serif;
 }
-.div {
-  background: #ffffff;
-  height: 2302px;
-  position: relative;
-  overflow: hidden;
+
+body {
+    background: #ffffff;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    padding: 20px;
 }
-.div2 {
-  color: #ffffff;
-  text-align: center;
-  font-family: "Roboto-Bold", sans-serif;
-  font-size: 40px;
-  line-height: 48px;
-  font-weight: 700;
-  position: absolute;
-  left: 420px;
-  top: 128px;
-  width: 614px;
-  height: 80px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-}
-.line-73 {
-  margin-top: -10px;
-  border-style: solid;
-  border-color: #000000;
-  border-width: 10px 0 0 0;
-  width: 249px;
-  height: 0px;
-  position: absolute;
-  left: 73px;
-  top: 431px;
-}
-.rectangle-4141 {
-  background: #ffffff;
-  border-style: solid;
-  border-color: rgba(0, 0, 0, 0.2);
-  border-width: 3px;
-  width: 1279px;
-  height: 1551px;
-  position: absolute;
-  left: 73px;
-  top: 470px;
-}
-.please-write-your-story {
-  color: rgba(0, 0, 0, 0.31);
-  text-align: center;
-  font-family: "Roboto-Medium", sans-serif;
-  font-size: 50px;
-  line-height: 48px;
-  font-weight: 500;
-  position: absolute;
-  left: 118px;
-  top: 512px;
-  width: 595px;
-  height: 139px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-}
-.primary {
-  background: #000000;
-  border-radius: 20px;
-  padding: 10px 12px 10px 12px;
-  display: flex;
-  flex-direction: column;
-  gap: 0px;
-  align-items: center;
-  justify-content: center;
-  width: 336px;
-  height: 99px;
-  position: absolute;
-  left: 1016px;
-  top: 2089px;
-}
-.title {
-  color: #ffffff;
-  text-align: center;
-  font-family: "Roboto-Medium", sans-serif;
-  font-size: 36px;
-  line-height: 22px;
-  font-weight: 500;
-  position: relative;
-  width: 154px;
-}
-.arrow-1 {
-  width: 49px;
-  height: 0px;
-  position: absolute;
-  left: 122px;
-  top: 2128px;
-  transform: translate(-54px, -36.82px);
-  overflow: visible;
-}
-.div3 {
-  color: #000000;
-  text-align: center;
-  font-family: "Roboto-Medium", sans-serif;
-  font-size: 36px;
-  line-height: 22px;
-  font-weight: 500;
-  position: absolute;
-  left: 122px;
-  top: 2087px;
-  width: 170px;
-  height: 82px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-}
-.rectangle-4142 {
-  background: #ffffff;
-  border-style: solid;
-  border-color: rgba(0, 0, 0, 0.2);
-  border-width: 3px;
-  width: 598px;
-  height: 97px;
-  position: absolute;
-  left: 75px;
-  top: 281px;
-}
-.title-input {
-  color: rgba(0, 0, 0, 0.42);
-  text-align: center;
-  font-family: "Roboto-Bold", sans-serif;
-  font-size: 36px;
-  line-height: 48px;
-  font-weight: 700;
-  position: absolute;
-  left: 75px;
-  top: 289px;
-  width: 283px;
-  height: 81px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-}
-.div4 {
-  color: rgba(0, 0, 0, 0.42);
-  text-align: center;
-  font-family: "Roboto-Bold", sans-serif;
-  font-size: 36px;
-  line-height: 48px;
-  font-weight: 700;
-  position: absolute;
-  left: 1016px;
-  top: 370px;
-  width: 418px;
-  height: 75px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-}
-.vector {
-  width: 2.11%;
-  height: 1.3%;
-  position: absolute;
-  right: 12.89%;
-  left: 85%;
-  bottom: 81.62%;
-  top: 17.07%;
-  overflow: visible;
-}
-.vector2 {
-  width: 2.11%;
-  height: 1.35%;
-  position: absolute;
-  right: 23.17%;
-  left: 74.72%;
-  bottom: 81.58%;
-  top: 17.07%;
-  overflow: visible;
-}
-.section {
-  background: rgba(247, 166, 166, 0.6);
-  padding: 60px 0px 60px 0px;
-  display: flex;
-  flex-direction: row;
-  gap: 60px;
-  align-items: center;
-  justify-content: center;
-  width: 100%;
-  height: 98px;
-  position: absolute;
-  left: 0px;
-  top: 74px;
-  overflow: hidden;
-}
-.container {
-  display: flex;
-  flex-direction: column;
-  gap: 24px;
-  align-items: center;
-  justify-content: flex-start;
-  flex: 1;
-  position: relative;
-}
-.title2 {
-  color: #ffffff;
-  text-align: center;
-  font-family: "Roboto-Bold", sans-serif;
-  font-size: 40px;
-  line-height: 48px;
-  font-weight: 700;
-  position: relative;
-  width: 520px;
-}
-.vector-200 {
-  flex-shrink: 0;
-  height: 0px;
-  position: absolute;
-  right: 0px;
-  left: 0px;
-  bottom: -40px;
-  overflow: visible;
-}
+
+/* Top Bar */
 .top-bar {
-  background: #ffffff;
-  padding: 20px;
-  display: flex;
-  flex-direction: row;
-  gap: 20px;
-  align-items: center;
-  justify-content: center;
-  width: 100%;
-  height: 80px;
-  position: absolute;
-  left: 0px;
-  top: -5px;
-  box-shadow: 0px 0px 6px 0px rgba(0, 0, 0, 0.12);
-  overflow: hidden;
-}
-.rectangle-4137 {
-  background: rgba(0, 0, 0, 0.1);
-  border-radius: 100px;
-  flex-shrink: 0;
-  width: 40px;
-  height: 40px;
-  position: relative;
+    width: 100%;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 20px;
+    background-color: #ffffff;
+    box-shadow: 0px 2px 4px rgba(0, 0, 0, 0.1);
 }
 .title3 {
-  color: #000000;
-  text-align: left;
-  font-family: "Roboto-Medium", sans-serif;
-  font-size: 28px;
-  line-height: 36px;
-  font-weight: 500;
-  position: relative;
-  width: 900px;
-  height: 36px;
+    font-size: 20px;
+    font-weight: bold;
+    color: #333;
 }
 .navigation {
-  background: #ffffff;
-  display: flex;
-  flex-direction: row;
-  gap: 40px;
-  align-items: center;
-  justify-content: center;
-  flex-shrink: 0;
-  position: relative;
+    display: flex;
+    align-items: center;
+    gap: 20px;
 }
 .tab {
-  color: #000000;
-  text-align: left;
-  font-family: "Roboto-Regular", sans-serif;
-  font-size: 16px;
-  line-height: 24px;
-  font-weight: 400;
-  position: relative;
-  width: 62px;
+    font-size: 14px;
+    color: #333;
 }
-.textfield {
-  border-radius: 6px;
-  border-style: solid;
-  border-color: rgba(0, 0, 0, 0.1);
-  border-width: 1px;
-  padding: 8px;
-  display: flex;
-  flex-direction: row;
-  gap: 4px;
-  align-items: center;
-  justify-content: flex-end;
-  flex-shrink: 0;
-  width: 243px;
-  position: relative;
+.search-box {
+    position: relative;
+    display: flex;
+    align-items: center;
 }
 .text {
-  color: rgba(0, 0, 0, 0.5);
-  text-align: left;
-  font-family: "Roboto-Regular", sans-serif;
-  font-size: 14px;
-  line-height: 20px;
-  font-weight: 400;
-  position: relative;
-  flex: 1;
+    color: rgba(0, 0, 0, 0.5);
+    margin-right: 5px;
 }
 .ic-search {
-  flex-shrink: 0;
-  width: 20px;
-  height: 20px;
-  position: relative;
-  overflow: visible;
+    width: 16px;
+    height: 16px;
+}
+
+/* Section Header */
+.section {
+    width: 100%;
+    background-color: rgba(247, 166, 166, 0.6);
+    padding: 20px 0;
+    text-align: center;
+}
+.title2 {
+    font-size: 24px;
+    color: #ffffff;
+    font-weight: bold;
+}
+
+/* Main Content */
+.content {
+    width: 100%;
+    max-width: 600px;
+    margin-top: 20px;
+}
+.label {
+    font-size: 16px;
+    margin-bottom: 5px;
+    font-weight: bold;
+}
+.title-input-box {
+    border: 1px solid #ddd;
+    padding: 10px;
+    border-radius: 4px;
+    margin-bottom: 5px;
+}
+.title-input {
+    border: none;
+    width: 100%;
+    font-size: 16px;
+    outline: none;
+}
+.underline {
+    width: 100%;
+    height: 2px;
+    background-color: #000;
+    margin-bottom: 20px;
+}
+.story-box {
+    border: 1px solid #bbb;
+    padding: 20px;
+    min-height: 300px;
+}
+.story-box textarea {
+    width: 100%;
+    height: 100%;
+    border: none;
+    resize: none;
+    font-size: 16px;
+    color: rgba(0, 0, 0, 0.5);
+    outline: none;
+}
+.story-box textarea::placeholder {
+    color: rgba(0, 0, 0, 0.5);
+}
+
+/* Action Buttons */
+.buttons {
+    display: flex;
+    justify-content: space-between;
+    width: 100%;
+    max-width: 600px;
+    margin-top: 20px;
+}
+.exit-button {
+    font-size: 16px;
+    color: #000;
+}
+.publish-button {
+    font-size: 16px;
+    color: #fff;
+    background-color: #000;
+    padding: 10px 20px;
+    border-radius: 5px;
 }

--- a/src/main/resources/static/styles.login_after.css
+++ b/src/main/resources/static/styles.login_after.css
@@ -1,3 +1,12 @@
+.div {
+  background: #ffffff; /* 배경 색상 */
+  border-radius: 20px; /* 모서리 둥글게 */
+  height: calc(100% - 40px); /* 페이지 높이에 여유 공간 추가 */
+  width: 1400px; /* 너비 줄이기 */
+  margin: 0 auto; /* 중앙 정렬 */
+  box-shadow: 0px 0px 10px rgba(0, 0, 0, 0.5); /* 그림자 */
+}
+
 .div,
 .div * {
   box-sizing: border-box;

--- a/src/main/resources/static/styles.login_before.css
+++ b/src/main/resources/static/styles.login_before.css
@@ -474,7 +474,7 @@
     align-items: center; /* 중앙 정렬 */
     justify-content: center;
     flex-shrink: 0;
-    width: 360px; /* 기존 너비 유지 */
+    width: 270px; /* 기존 너비 유지 */
     height: auto; /* 높이를 자동으로 조정 */
     padding: 16px; /* 내부 여백 추가 */
     margin: 0 auto; /* 좌우 중앙 정렬 */

--- a/src/main/resources/static/styles.todo_list.css
+++ b/src/main/resources/static/styles.todo_list.css
@@ -25,8 +25,6 @@
   top: 239px; /* 필요한 경우 이 값 조정 */
   transform: translateX(-50%); /* 요소를 왼쪽으로 50% 이동시켜 중앙 정렬 */
 }
-
-
 .text {
   color: rgba(0, 0, 0, 0.5);
   text-align: left;
@@ -56,7 +54,6 @@
   top: 314px; /* 필요한 경우 이 값 조정 */
   transform: translateX(-50%); /* 요소를 왼쪽으로 50% 이동시켜 중앙 정렬 */
 }
-
 .frame-427318969 {
   background: #d9d9d9;
   border-radius: 100px;
@@ -72,39 +69,23 @@
   position: relative;
 }
 .group {
-  flex-shrink: 0;
   width: 40px;
   height: 40px;
-  position: relative;
-  overflow: visible;
 }
+
 .list-1 {
-  color: #000000;
-  text-align: center;
-  font-family: "Roboto-Medium", sans-serif;
+  flex-grow: 1;
   font-size: 30px;
-  line-height: 22px;
   font-weight: 500;
-  position: relative;
-  width: 113px;
-  height: 32px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-}
-._1-min {
-  color: #817f7f;
+  color: #000;
   text-align: center;
-  font-family: "Roboto-Medium", sans-serif;
+}
+
+._1-min {
   font-size: 20px;
-  line-height: 22px;
   font-weight: 500;
-  position: relative;
-  width: 46px;
-  height: 22px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
+  color: #817f7f;
+  text-align: right;
 }
 .frame-427318978 {
   display: flex;

--- a/src/main/resources/static/styles.todo_list_detail.css
+++ b/src/main/resources/static/styles.todo_list_detail.css
@@ -905,11 +905,15 @@ input[type="text"] {
 }
 
 .title-search {
+  color: rgba(0, 0, 0, 0.97);
   font-size: 20px;
-
+  margin-bottom: 10px;
+  text-align: right; /* 텍스트를 오른쪽 정렬 */
+  width: 400px; /* textfield2와 같은 폭 */
 }
 
 .container-title-search {
+  font-size: 40px;
   display: flex;
   align-items: center; /* 세로 중앙 정렬 */
   justify-content: flex-end; /* 오른쪽 정렬 */
@@ -930,13 +934,16 @@ input[type="text"] {
   align-items: center;
   border-radius: 6px;
   border: 1px solid rgba(0, 0, 0, 0.1);
-  padding: 8px;
-  width: 180px; /* 검색창 너비 조정 */
+  padding: 2px 2px; /* 상하 폭을 줄이기 위해 padding 값을 조정 */
+  width: 400px; /* 좌우 폭을 늘리기 위해 width 값을 조정 */
 }
+
 /* 입력 필드 스타일 */
 .textfield2 .text {
+  font-size: 15px;
   border: none;
   outline: none;
+  width: 100%; /* 검색창 안에서 너비를 전체로 설정 */
 }
 
 /* 검색 아이콘 스타일 */
@@ -946,6 +953,7 @@ input[type="text"] {
   margin-left: 10px;
   cursor: pointer;
 }
+
 .to-do-list-bar {
   background: rgba(247, 166, 166, 0.6);
   padding: 60px 0px 60px 0px;

--- a/src/main/resources/static/styles.todo_list_detail.css
+++ b/src/main/resources/static/styles.todo_list_detail.css
@@ -942,13 +942,8 @@
 input[type="text"] {
     width: 100%; /* 너비를 박스에 맞추기 */
     padding: 10px; /* 안쪽 여백 */
-    border: 1px solid rgba(0, 0, 0, 0.1); /* 테두리 스타일 */
-    border-radius: 4px; /* 둥근 모서리 */
     text-align: center; /* 텍스트 중앙 정렬 */
-    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1); /* 그림자 추가 */
 }
-
-
 .div13 {
   color: #000000;
   text-align: left;
@@ -956,11 +951,56 @@ input[type="text"] {
   font-size: 30px;
   line-height: 20px;
   font-weight: 400;
-  position: absolute;
+  position: relative;
+  display: inline-block;
+  margin-right: 20px; /* 우측 여백 설정 */
   left: 870px;
   top: 162px;
-  width: 403px;
+  width: 200px; /* 너비 조정 */
   height: 47px;
+}
+
+.title-search {
+  font-size: 20px;
+
+}
+
+.container-title-search {
+  display: flex;
+  align-items: center; /* 세로 중앙 정렬 */
+  justify-content: flex-end; /* 오른쪽 정렬 */
+  flex-direction: column; /* 세로 방향 정렬 */
+  position: absolute;
+  right: 150px;
+  top: 162px;
+}
+
+.title-search {
+  font-size: 20px;
+  margin-bottom: 10px; /* 검색 필드와의 간격 조정 */
+  text-align: right; /* 오른쪽 정렬 */
+}
+/* 검색 필드 스타일 */
+.textfield2 {
+  display: flex;
+  align-items: center;
+  border-radius: 6px;
+  border: 1px solid rgba(0, 0, 0, 0.1);
+  padding: 8px;
+  width: 180px; /* 검색창 너비 조정 */
+}
+/* 입력 필드 스타일 */
+.textfield2 .text {
+  border: none;
+  outline: none;
+}
+
+/* 검색 아이콘 스타일 */
+.textfield2 .ic-search2 {
+  width: 20px;
+  height: 20px;
+  margin-left: 10px;
+  cursor: pointer;
 }
 .to-do-list-bar {
   background: rgba(247, 166, 166, 0.6);

--- a/src/main/resources/static/styles.todo_list_detail.css
+++ b/src/main/resources/static/styles.todo_list_detail.css
@@ -104,22 +104,7 @@
   align-items: center;
   justify-content: center;
 }
-.img-2 {
-  width: 406px;
-  height: 85px;
-  position: absolute;
-  left: 934px;
-  top: 1255px;
-  overflow: hidden;
-}
-.lol {
-  width: 50px;
-  height: 50px;
-  position: absolute;
-  left: 274px;
-  top: 20px;
-  object-fit: cover;
-}
+
 ._5 {
   color: #000000;
   text-align: left;
@@ -135,14 +120,6 @@
   display: flex;
   align-items: center;
   justify-content: flex-start;
-}
-.surprised {
-  width: 50px;
-  height: 50px;
-  position: absolute;
-  left: 155px;
-  top: 20px;
-  object-fit: cover;
 }
 ._4 {
   color: #000000;
@@ -160,16 +137,7 @@
   align-items: center;
   justify-content: flex-start;
 }
-.vector {
-  width: 13.66%;
-  height: 67.33%;
-  position: absolute;
-  right: 80.27%;
-  left: 6.07%;
-  bottom: 25.62%;
-  top: 7.06%;
-  overflow: visible;
-}
+
 ._6 {
   color: #000000;
   text-align: left;
@@ -244,24 +212,6 @@
   overflow: hidden;  /* 내용 넘침 숨김 */
 }
 
-.img-1 {
-  width: 406px;
-  height: 85px;
-  position: absolute;
-  left: 934px;
-  top: 974px;
-  overflow: hidden;
-}
-.vector2 {
-  width: 13.66%;
-  height: 67.33%;
-  position: absolute;
-  right: 80.27%;
-  left: 6.07%;
-  bottom: 25.62%;
-  top: 7.06%;
-  overflow: visible;
-}
 .div6 {
   color: rgba(0, 0, 0, 0.42);
   text-align: center;
@@ -295,8 +245,6 @@
     0 -2px 10px rgba(0, 0, 0, 0.05),  /* 위쪽 그림자 */
     2px 0 10px rgba(0, 0, 0, 0.05),   /* 오른쪽 그림자 */
     -2px 0 10px rgba(0, 0, 0, 0.05);  /* 왼쪽 그림자 */
-
-
 }
 
 .to-do-list-a {
@@ -357,10 +305,6 @@
     2px 0 10px rgba(0, 0, 0, 0.05),   /* 오른쪽 그림자 */
     -2px 0 10px rgba(0, 0, 0, 0.05);  /* 왼쪽 그림자 */
 }
-
-
-
-
 
 .div10 {
   color: rgba(0, 0, 0, 0.42);
@@ -1088,3 +1032,90 @@ input[type="text"] {
     padding: 20px;
     background-color: #f4f4f4;
 }
+
+.pagination {
+    display: flex;
+    justify-content: center; /* 중앙 정렬 */
+    margin-top: 20px;
+    position: absolute;
+    left: 50%;
+    transform: translateX(-50%);
+    top: 1000px;
+    list-style: none; /* 리스트 점 제거 */
+    padding: 0;
+}
+
+.page-item {
+    margin: 0 5px; /* 페이지 아이템 간 간격 */
+}
+
+.page-item a.page-link {
+    display: inline-block;
+    padding: 8px 16px;
+    color: #F7A6A6;
+    text-decoration: none;
+    border: 1px solid #F7A6A6;
+    border-radius: 4px;
+    transition: background-color 0.3s;
+}
+
+.page-item a.page-link:hover {
+    background-color: #F7A6A6; /* 호버 시 배경색 변경 */
+    color: #ffffff; /* 호버 시 글자색 변경 */
+}
+
+.page-item.disabled .page-link {
+    color: #c0c0c0; /* 비활성화된 링크 색상 */
+    pointer-events: none; /* 클릭 불가 */
+    border-color: #c0c0c0;
+}
+
+.page-item.active .page-link {
+    background-color: #F7A6A6; /* 활성화된 페이지의 배경색 */
+    color: #ffffff;
+    border-color: #F7A6A6;
+}
+
+.reactions {
+    display: flex;
+    justify-content: flex-end;
+    gap: 10px;
+    font-size: 30px;
+    margin-bottom: 5px;
+    position: relative; /* 반응 아이콘이 div 내부에 위치하도록 설정 */
+    right: 0; /* 오른쪽 정렬 */
+    top: -20px; /* 위로 올려 위치 조정 */
+    z-index: 10; /* 다른 요소 위에 표시되도록 설정 */
+}
+
+.div3, .div5 {
+    border: none;
+    width: 1250px !important;
+    height: 176px;
+    padding: 5px;
+    font-size: 18px;
+    line-height: 1.2;
+    box-sizing: border-box;
+    position: absolute;
+    left: 67px;
+    box-shadow:
+        0 2px 10px rgba(0, 0, 0, 0.05),
+        0 -2px 10px rgba(0, 0, 0, 0.05),
+        2px 0 10px rgba(0, 0, 0, 0.05),
+        -2px 0 10px rgba(0, 0, 0, 0.05);
+    overflow: visible; /* 이모지가 잘리지 않도록 설정 */
+}
+
+.pagination1 {
+    display: flex;
+    justify-content: center; /* 중앙 정렬 */
+    list-style: none;
+    padding: 0;
+    margin-top: 1590px; /* div3 하단과의 간격 */
+    position: relative;
+}
+
+
+
+
+

--- a/src/main/resources/templates/login_before.html
+++ b/src/main/resources/templates/login_before.html
@@ -1,4 +1,12 @@
-<link rel="stylesheet" href="/styles.login_before.css">
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>할랭왕</title>
+  <link rel="stylesheet" href="/styles.login_before.css">
+</head>
+<body>
 <div class="div">
   <div class="top-bar">
     <div class="rectangle-4137"></div>
@@ -8,13 +16,14 @@
       <div class="tab">회원가입</div>
     </div>
   </div>
+
   <div class="ranking-container">
     <div class="ranking-bar">
       <div class="title2">
-        <span>
-          <span class="title-2-span">RanKings</span>
-          <span class="title-2-span2">🏆</span>
-        </span>
+                <span>
+                    <span class="title-2-span">RanKings</span>
+                    <span class="title-2-span2">🏆</span>
+                </span>
       </div>
     </div>
     <div class="ranking-list">
@@ -51,7 +60,7 @@
         </div>
       </div>
     </div>
-    <img class="vector-200" src="vector-2000.svg" />
+
     <div class="ranking-list-2">
       <div class="container">
         <div class="title4">일간 랭킹</div>
@@ -67,7 +76,6 @@
               <div class="subtitle4">9:00 AM</div>
             </div>
             <div class="subtitle5">1등</div>
-            <img class="vector-2002" src="vector-2001.svg" />
           </div>
         </div>
         <div class="row">
@@ -80,7 +88,6 @@
               <div class="subtitle4">11:30 AM</div>
             </div>
             <div class="subtitle5">2등</div>
-            <img class="vector-2003" src="vector-2002.svg" />
           </div>
         </div>
         <div class="row">
@@ -93,16 +100,15 @@
               <div class="subtitle4">3:00 PM</div>
             </div>
             <div class="subtitle5">3등</div>
-            <img class="vector-2004" src="vector-2003.svg" />
           </div>
         </div>
         <button class="button">
           <div class="title6">순위 더 보기</div>
         </button>
       </div>
-      <img class="vector-2005" src="vector-2004.svg" />
     </div>
   </div>
+
   <div class="section">
     <div class="container2">
       <div class="title7">To-Do List</div>
@@ -113,8 +119,8 @@
         <div class="title6">검색하기</div>
       </button>
     </div>
-    <img class="vector-2006" src="vector-2005.svg" />
   </div>
+
   <div class="todo-list">
     <div class="list2">
       <div class="row">
@@ -127,7 +133,6 @@
             <div class="subtitle4">제목 : 오늘의 보성녹차왕</div>
             <div class="subtitle4">댓글 / 추천 수</div>
           </div>
-          <img class="vector-2007" src="vector-2006.svg" />
         </div>
       </div>
       <div class="row">
@@ -140,7 +145,6 @@
             <div class="subtitle4">제목 : 오늘의 발표왕</div>
             <div class="subtitle4">댓글 / 추천 수</div>
           </div>
-          <img class="vector-2008" src="vector-2007.svg" />
         </div>
       </div>
       <div class="row">
@@ -153,7 +157,6 @@
             <div class="subtitle4">제목 : 오늘의 배드민턴왕</div>
             <div class="subtitle4">댓글 / 추천 수</div>
           </div>
-          <img class="vector-2009" src="vector-2008.svg" />
         </div>
       </div>
       <div class="row">
@@ -165,15 +168,15 @@
             <div class="title5">Prepare for client pitch</div>
             <div class="subtitle4">Deadline: Tomorrow</div>
           </div>
-          <img class="vector-20010" src="vector-2009.svg" />
         </div>
       </div>
     </div>
-    <img class="vector-20011" src="vector-20010.svg" />
   </div>
+
   <div class="_11-12-13-14-15-16-17-18-19-20">
     &lt; 이전 | 11 12 13 14 15 16 17 18 19 20 | 다음 &gt;
   </div>
+
   <div class="section2">
     <div class="container3">
       <div class="title8">Contact Us</div>
@@ -182,3 +185,5 @@
     </div>
   </div>
 </div>
+</body>
+</html>

--- a/src/main/resources/templates/login_page.html
+++ b/src/main/resources/templates/login_page.html
@@ -19,7 +19,7 @@
 </div>
 
 <div class="login-container">
-    <form class="login-form" th:action="@{/user/login_page}" method="post">
+    <form class="login-form" th:action="@{/user/login}" method="post">
         <div class="form-group">
             <label for="username">아이디</label>
             <input type="text" id="username" placeholder="Enter your username" name="username">

--- a/src/main/resources/templates/login_page.html
+++ b/src/main/resources/templates/login_page.html
@@ -19,7 +19,7 @@
 </div>
 
 <div class="login-container">
-    <form class="login-form" th:action="@{/user/login}" method="post">
+    <form class="login-form" th:action="@{/user/login_page}" method="post">
         <div class="form-group">
             <label for="username">아이디</label>
             <input type="text" id="username" placeholder="Enter your username" name="username">

--- a/src/main/resources/templates/remembrance_page.html
+++ b/src/main/resources/templates/remembrance_page.html
@@ -66,6 +66,9 @@
             <textarea placeholder="댓글을 입력하세요"></textarea>
             <button class="submit-comment">댓글 작성</button>
         </div>
+        <div class="pagination">
+            <a href="#">&lt; 이전</a> | 11 12 13 14 15 16 17 18 19 20 | <a href="#">다음 &gt;</a>
+        </div>
     </section>
 </div>
 </body>

--- a/src/main/resources/templates/retrospective_from_page.html
+++ b/src/main/resources/templates/retrospective_from_page.html
@@ -1,34 +1,47 @@
-<link rel="stylesheet" href="/retrospective_from_page.css">
-<div class="div">
-    <div class="div2">회고 작성</div>
-    <div class="line-73"></div>
-    <div class="rectangle-4141"></div>
-    <div class="please-write-your-story">Please write your story...</div>
-    <div class="primary">
-        <div class="title">발행하기</div>
-    </div>
-    <img class="arrow-1" src="arrow-10.svg" />
-    <div class="div3">나가기</div>
-    <div class="rectangle-4142"></div>
-    <div class="title-input">Title Input</div>
-    <div class="div4">공개 / 비공개</div>
-    <img class="vector" src="vector0.svg" />
-    <img class="vector2" src="vector1.svg" />
-    <div class="section">
-        <div class="container">
-            <div class="title2">회고</div>
-        </div>
-        <img class="vector-200" src="vector-2000.svg" />
-    </div>
-    <div class="top-bar">
-        <div class="rectangle-4137"></div>
-        <div class="title3">할랭왕</div>
-        <div class="navigation">
-            <div class="tab">로그아웃</div>
-            <div class="textfield">
-                <div class="text">Search in site</div>
-                <img class="ic-search" src="ic-search0.svg" />
-            </div>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>회고 작성</title>
+    <link rel="stylesheet" href="retrospective_from_page.css">
+</head>
+<body>
+<!-- Top Bar -->
+<div class="top-bar">
+    <div class="title3">할랭왕</div>
+    <div class="navigation">
+        <div class="tab">로그아웃</div>
+        <div class="search-box">
+            <input type="text" placeholder="Search">
+            <img src="/lens.png" alt="검색 아이콘" class="ic-search">
         </div>
     </div>
 </div>
+
+<!-- Section Header -->
+<div class="section">
+    <div class="title2">회고</div>
+</div>
+
+<!-- Main Content -->
+<div class="content">
+    <div class="label">제목</div>
+    <div class="title-input-box">
+        <input type="text" class="title-input" placeholder="Title Input">
+    </div>
+    <div class="underline"></div>
+    <input type="radio" name="privacy-options" value="other">공개
+    <input type="radio" name="privacy-options" value="other">비공개<br>
+    <div class="story-box">
+        <textarea id="retrospective" placeholder="회고 내용을 입력하세요."></textarea>
+    </div>
+</div>
+
+<!-- Action Buttons -->
+<div class="buttons">
+    <div class="exit-button">← 나가기</div>
+    <div class="publish-button">발행하기</div>
+</div>
+</body>
+</html>

--- a/src/main/resources/templates/todo_list.html
+++ b/src/main/resources/templates/todo_list.html
@@ -23,37 +23,14 @@
 
     <div class="frame-427318974">
         <div class="frame-427318969" th:each="todoList : ${paging}">
-            <img class="group" src="/group.png"/>
-            <div class="list-1" th:text="${todoList.title}"></div>
-            <div class="_1-min" th:text="${#temporals.format(todoList.createdDate, 'yyyy-MM-dd')}"></div>
+            <a th:href="@{|/todo_list/detail/${todoList.id}|}" style="display: flex; align-items: center; width: 100%;">
+                <img class="group" src="/group.png" alt="Group Icon"/>
+                <div class="list-1" th:text="${todoList.title}"></div>
+                <div class="_1-min" th:text="${#temporals.format(todoList.createdDate, 'yyyy-MM-dd')}"></div>
+            </a>
         </div>
     </div>
   </div>
-
-  <div class="frame-427318979">
-    <div class="frame-427318969">
-      <img class="group3" src="/group.png" />
-      <div class="list-3">List 3</div>
-      <div class="_1-min">1min</div>
-    </div>
-  </div>
-
-  <div class="frame-427318980">
-    <div class="frame-427318969">
-      <img class="group4" src="/group.png" />
-      <div class="list-4">List 4</div>
-      <div class="_1-min">1min</div>
-    </div>
-  </div>
-
-  <div class="frame-427318981">
-    <div class="frame-427318969">
-      <img class="group5" src="/group.png" />
-      <div class="list-5">List 5</div>
-      <div class="_1-min">1min</div>
-    </div>
-  </div>
-
 
     <div class="primary" sec:authorize="isAuthenticated()" th:if="${#authentication.getPrincipal().getUsername() == userName}">
         <div class="title">ToDoList 등록</div>

--- a/src/main/resources/templates/todo_list.html
+++ b/src/main/resources/templates/todo_list.html
@@ -23,48 +23,77 @@
 
     <div class="frame-427318974">
         <div class="frame-427318969" th:each="todoList : ${paging}">
-            <a th:href="@{|/todo_list/detail/${todoList.id}|}">
-                <img class="group" src="/group.png"/>
-                <div class="list-1" th:text="${todoList.title}"></div>
-                <div class="_1-min" th:text="${#temporals.format(todoList.createdDate, 'yyyy-MM-dd')}"></div>
-            </a>
+            <img class="group" src="/group.png"/>
+            <div class="list-1" th:text="${todoList.title}"></div>
+            <div class="_1-min" th:text="${#temporals.format(todoList.createdDate, 'yyyy-MM-dd')}"></div>
+        </div>
+    </div>
+  </div>
+
+  <div class="frame-427318979">
+    <div class="frame-427318969">
+      <img class="group3" src="/group.png" />
+      <div class="list-3">List 3</div>
+      <div class="_1-min">1min</div>
+    </div>
+  </div>
+
+  <div class="frame-427318980">
+    <div class="frame-427318969">
+      <img class="group4" src="/group.png" />
+      <div class="list-4">List 4</div>
+      <div class="_1-min">1min</div>
+    </div>
+  </div>
+
+  <div class="frame-427318981">
+    <div class="frame-427318969">
+      <img class="group5" src="/group.png" />
+      <div class="list-5">List 5</div>
+      <div class="_1-min">1min</div>
+    </div>
+  </div>
+
+
+    <div class="primary" sec:authorize="isAuthenticated()" th:if="${#authentication.getPrincipal().getUsername() == userName}">
+        <div class="title">ToDoList 등록</div>
+    </div>
+
+    <div class="primary2" sec:authorize="isAuthenticated()" th:if="${#authentication.getPrincipal().getUsername() == userName}">
+        <div class="title">ToDoList 수정</div>
+    </div>
+
+    <div class="frame-427318977">
+        <!-- 페이징처리 시작 -->
+        <div th:if="${!paging.isEmpty()}">
+            <ul class="pagination justify-content-center">
+                <li class="page-item" th:classappend="${!paging.hasPrevious} ? 'disabled'">
+                    <a class="page-link"
+                       th:href="@{|?page=${paging.number-1}|}">
+                        <span>이전</span>
+                    </a>
+                </li>
+                <li th:each="page: ${#numbers.sequence(0, paging.totalPages-1)}"
+                    th:classappend="${page == paging.number} ? 'active'"
+                    th:if="${page >= paging.number-5 and page <= paging.number+5}"
+                    class="page-item">
+                    <a th:text="${page+1}" class="page-link" th:href="@{|?page=${page}|}"></a>
+                </li>
+                <li class="page-item" th:classappend="${!paging.hasNext} ? 'disabled'">
+                    <a class="page-link" th:href="@{|?page=${paging.number+1}|}">
+                        <span>다음</span>
+                    </a>
+                </li>
+            </ul>
+        </div>
+        <!-- 페이징처리 끝 -->
+    </div>
+    <div class="top-bar">
+        <div class="rectangle-4137"></div>
+        <div class="title3">할랭왕</div>
+        <div class="navigation">
+            <div class="tab">로그아웃</div>
         </div>
     </div>
 </div>
 
-
-<div class="primary" sec:authorize="isAuthenticated()"
-     th:if="${#authentication.getPrincipal().getUsername() == userName}">
-    <div class="title">ToDoList 등록</div>
-</div>
-
-<div class="primary2" sec:authorize="isAuthenticated()"
-     th:if="${#authentication.getPrincipal().getUsername() == userName}">
-    <div class="title">ToDoList 수정</div>
-</div>
-
-<div class="frame-427318977">
-    <!-- 페이징처리 시작 -->
-    <div th:if="${!paging.isEmpty()}">
-        <ul class="pagination justify-content-center">
-            <li class="page-item" th:classappend="${!paging.hasPrevious} ? 'disabled'">
-                <a class="page-link"
-                   th:href="@{|?page=${paging.number-1}|}">
-                    <span>이전</span>
-                </a>
-            </li>
-            <li th:each="page: ${#numbers.sequence(0, paging.totalPages-1)}"
-                th:classappend="${page == paging.number} ? 'active'"
-                th:if="${page >= paging.number-5 and page <= paging.number+5}"
-                class="page-item">
-                <a th:text="${page+1}" class="page-link" th:href="@{|?page=${page}|}"></a>
-            </li>
-            <li class="page-item" th:classappend="${!paging.hasNext} ? 'disabled'">
-                <a class="page-link" th:href="@{|?page=${paging.number+1}|}">
-                    <span>다음</span>
-                </a>
-            </li>
-        </ul>
-    </div>
-    <!-- 페이징처리 끝 -->
-</div>

--- a/src/main/resources/templates/todo_list.html
+++ b/src/main/resources/templates/todo_list.html
@@ -1,5 +1,13 @@
-<link rel="stylesheet" href="/styles.todo_list.css">
-<link rel="stylesheet" href="/bootstrap.min.css">
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>ToDo List</title>
+    <link rel="stylesheet" href="/styles.todo_list.css">
+    <link rel="stylesheet" href="/bootstrap.min.css">
+</head>
+<body>
 <div class="to-do-list">
     <div class="top-bar">
         <div class="rectangle-4137"></div>
@@ -30,7 +38,6 @@
             </a>
         </div>
     </div>
-  </div>
 
     <div class="primary" sec:authorize="isAuthenticated()" th:if="${#authentication.getPrincipal().getUsername() == userName}">
         <div class="title">ToDoList 등록</div>
@@ -45,8 +52,7 @@
         <div th:if="${!paging.isEmpty()}">
             <ul class="pagination justify-content-center">
                 <li class="page-item" th:classappend="${!paging.hasPrevious} ? 'disabled'">
-                    <a class="page-link"
-                       th:href="@{|?page=${paging.number-1}|}">
+                    <a class="page-link" th:href="@{|?page=${paging.number-1}|}">
                         <span>이전</span>
                     </a>
                 </li>
@@ -65,6 +71,7 @@
         </div>
         <!-- 페이징처리 끝 -->
     </div>
+
     <div class="top-bar">
         <div class="rectangle-4137"></div>
         <div class="title3">할랭왕</div>
@@ -73,4 +80,5 @@
         </div>
     </div>
 </div>
-
+</body>
+</html>

--- a/src/main/resources/templates/todo_list_detail.html
+++ b/src/main/resources/templates/todo_list_detail.html
@@ -28,7 +28,7 @@
 
         <!-- 검색 필드 -->
         <div class="container-title-search">
-            <div class="title-search">Todo 리스트 제목</div>
+            <div class="title-search">제목</div>
             <div class="textfield2">
                 <input type="text" class="text" placeholder="title search">
                 <img class="ic-search2" src="/search.png" alt="Search">

--- a/src/main/resources/templates/todo_list_detail.html
+++ b/src/main/resources/templates/todo_list_detail.html
@@ -1,4 +1,12 @@
-<link href="/styles.todo_list_detail.css" rel="stylesheet">
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>할랭왕</title>
+    <link href="/styles.todo_list_detail.css" rel="stylesheet">
+</head>
+<body>
 <div class="to-do-list">
     <!-- 상단 바 -->
     <div class="top-bar">
@@ -60,7 +68,6 @@
                 </div>
             </div>
         </div>
-
     </div>
 
     <!-- ToDo List 상세 바 -->
@@ -104,6 +111,22 @@
             <div class="_1-min">1min</div>
         </div>
 
+        <ul class="pagination justify-content-center">
+            <li class="page-item disabled">
+                <a class="page-link" href="?page=-1">
+                    <span>이전</span>
+                </a>
+            </li>
+            <li class="page-item active">
+                <a class="page-link" href="?page=0">1</a>
+            </li>
+            <li class="page-item disabled">
+                <a class="page-link" href="?page=1">
+                    <span>다음</span>
+                </a>
+            </li>
+        </ul>
+
         <!-- 버튼들 -->
         <button class="button2" sec:authorize="isAuthenticated()"
                 th:if="${username == #authentication.getPrincipal().getUsername()}">
@@ -115,7 +138,7 @@
             <div class="title6">ToDO-Card 등록</div>
         </a>
         <button class="button4" sec:authorize="isAuthenticated()"
-                th:if="${username == #authentication.getPrincipal().getUsername()}" >
+                th:if="${username == #authentication.getPrincipal().getUsername()}">
             <div class="title6">회고 등록</div>
         </button>
     </div>
@@ -154,28 +177,42 @@
 
         <!-- 댓글과 이모티콘 -->
         <div class="div6">댓글</div>
-        <div class="div3">
-            <div class="div4">엄준식 짱짱맨</div>
-        </div>
-        <div class="img-1">
-            <img class="lol" src="/lol.png"/>
-            <div class="_5">5</div>
-            <img class="surprised" src="/surprised.png"/>
-            <div class="_4">4</div>
-            <img class="vector2" src="/vector.png"/>
-            <div class="_6">6</div>
+
+        <!-- reactions를 div5 외부로 이동하고 오른쪽 정렬 및 위로 이동 -->
+        <div class="reactions" style="position: absolute; right: 120px; top: 1015px;">
+            <span onclick="increaseCount(this)">👍 <span class="count">3</span></span>
+            <span onclick="increaseCount(this)">👎 <span class="count">4</span></span>
+            <span onclick="increaseCount(this)">❤️ <span class="count">5</span></span>
         </div>
         <div class="div5">
             <div class="div4">엄준식 짱짱맨</div>
         </div>
-        <div class="img-2">
-            <img class="lol" src="/lol.png"/>
-            <div class="_5">5</div>
-            <img class="surprised" src="/surprised.png"/>
-            <div class="_4">4</div>
-            <img class="vector" src="/vector.png"/>
-            <div class="_6">6</div>
+
+        <!-- reactions를 div3 외부로 이동하고 오른쪽 정렬 및 위로 이동 -->
+        <div class="reactions" style="position: absolute; right: 120px; top: 1280px;">
+            <span onclick="increaseCount(this)">👍 <span class="count">6</span></span>
+            <span onclick="increaseCount(this)">👎 <span class="count">7</span></span>
+            <span onclick="increaseCount(this)">❤️ <span class="count">8</span></span>
         </div>
+        <div class="div3">
+            <div class="div4">엄준식 짱짱맨</div>
+        </div>
+
+        <ul class="pagination1 justify-content-center">
+            <li class="page-item disabled">
+                <a class="page-link" href="?page=-1">
+                    <span>이전</span>
+                </a>
+            </li>
+            <li class="page-item active">
+                <a class="page-link" href="?page=0">1</a>
+            </li>
+            <li class="page-item disabled">
+                <a class="page-link" href="?page=1">
+                    <span>다음</span>
+                </a>
+            </li>
+        </ul>
 
         <!-- 댓글 입력 필드 -->
         <textarea class="input-field3" placeholder="댓글을 입력하세요"></textarea>
@@ -187,3 +224,13 @@
         </button>
     </div>
 </div>
+</body>
+</html>
+
+<script>
+    function increaseCount(element) {
+        const countElement = element.querySelector(".count");
+        let count = parseInt(countElement.textContent);
+        countElement.textContent = count + 1;
+    }
+</script>

--- a/src/main/resources/templates/todo_list_detail.html
+++ b/src/main/resources/templates/todo_list_detail.html
@@ -1,6 +1,46 @@
 <link href="/styles.todo_list_detail.css" rel="stylesheet">
 <div class="to-do-list">
+    <!-- 상단 바 -->
+    <div class="top-bar">
+        <div class="rectangle-4137"></div>
+        <div class="title5">할랭왕</div>
+        <div class="navigation">
+            <div class="tab">로그아웃</div>
+        </div>
+    </div>
+
+    <!-- ToDo List 제목 바 -->
     <div class="_1">
+        <div class="to-do-list-bar">
+            <div class="container">
+                <div class="title2">ToDo List</div>
+            </div>
+            <img class="vector-2003" src="vector-2002.svg"/>
+        </div>
+
+        <!-- 검색 필드 -->
+        <div class="container-title-search">
+            <div class="title-search">Todo 리스트 제목</div>
+            <div class="textfield2">
+                <input type="text" class="text" placeholder="title search">
+                <img class="ic-search2" src="/search.png" alt="Search">
+            </div>
+        </div>
+
+        <div class="container2">
+            <div class="container3">
+                <div class="title4">시간표(TimeTable)</div>
+                <div class="y-axis">Percentage</div>
+                <div class="graph">
+                    <div class="ellipse-95"></div>
+                    <div class="ellipse-96"></div>
+                    <div class="ellipse-97"></div>
+                </div>
+                <div class="x-axis">Tasks</div>
+            </div>
+        </div>
+
+        <!-- 메트릭 및 시간표 -->
         <div class="list">
             <div class="row">
                 <div class="metric">
@@ -20,38 +60,51 @@
                 </div>
             </div>
         </div>
-        <div class="container2">
-            <div class="container3">
-                <div class="title4">시간표(TimeTable)</div>
-                <div class="y-axis">Percentage</div>
-                <div class="graph">
-                    <div class="ellipse-95"></div>
-                    <div class="ellipse-96"></div>
-                    <div class="ellipse-97"></div>
-                </div>
-                <div class="x-axis">Tasks</div>
-            </div>
-        </div>
-        <div class="textfield2">
-            <input type="text" class="text" th:value="${todoList.title}" />
-            <img class="ic-search2" src="/search.png"/>
-        </div>
-        <div class="div13">제목</div>
-        <div class="to-do-list-bar">
-            <div class="container">
-                <div class="title2">ToDo List</div>
-            </div>
-            <img class="vector-2003" src="vector-2002.svg"/>
-        </div>
+
     </div>
-    <div class="top-bar">
-        <div class="rectangle-4137"></div>
-        <div class="title5">할랭왕</div>
-        <div class="navigation">
-            <div class="tab">로그아웃</div>
-        </div>
-    </div>
+
+    <!-- ToDo List 상세 바 -->
     <div class="_2">
+        <div class="to-do-list-detail-bar">
+            <div class="container">
+                <div class="title2">ToDo List 상세</div>
+            </div>
+            <img class="vector-2002" src="vector-2001.svg"/>
+        </div>
+
+        <!-- 검색 박스 및 ToDo 카드 -->
+        <div class="search-box2">
+            <input class="textfield" type="text" placeholder="ToDo Card List Search">
+            <img class="ic-search" src="/search.png" alt="Search">
+        </div>
+
+        <div class="frame-427318974">
+            <img class="group5" src="/group.png"/>
+            <div class="_5-km">런닝 5km</div>
+            <div class="_1-min">1min</div>
+        </div>
+        <div class="frame-427318970">
+            <img class="group4" src="/group.png"/>
+            <div class="div12">밥 세끼 먹기</div>
+            <div class="_1-min">1min</div>
+        </div>
+        <div class="frame-427318971">
+            <img class="group3" src="/group.png"/>
+            <div class="div11">깃허브 공부하기</div>
+            <div class="_1-min">1min</div>
+        </div>
+        <div class="frame-427318975">
+            <img class="group2" src="/group.png"/>
+            <div class="to-do-card-4">ToDo Card 4</div>
+            <div class="_1-min">1min</div>
+        </div>
+        <div class="frame-427318978">
+            <img class="group" src="/group.png"/>
+            <div class="to-do-card-5">ToDo Card 5</div>
+            <div class="_1-min">1min</div>
+        </div>
+
+        <!-- 버튼들 -->
         <button class="button2" sec:authorize="isAuthenticated()"
                 th:if="${username == #authentication.getPrincipal().getUsername()}">
             <div class="title6">ToDO-Card 수정</div>
@@ -65,72 +118,22 @@
                 th:if="${username == #authentication.getPrincipal().getUsername()}" >
             <div class="title6">회고 등록</div>
         </button>
-        <div class="frame-427318978">
-            <img class="group" src="/group.png"/>
-            <div class="to-do-card-5">ToDo Card 5</div>
-            <div class="_1-min">1min</div>
-        </div>
-        <div class="frame-427318975">
-            <img class="group2" src="/group.png"/>
-            <div class="to-do-card-4">ToDo Card 4</div>
-            <div class="_1-min">1min</div>
-        </div>
-        <div class="frame-427318971">
-            <img class="group3" src="/group.png"/>
-            <div class="div11">깃허브 공부하기</div>
-            <div class="_1-min">1min</div>
-        </div>
-        <div class="frame-427318970">
-            <img class="group4" src="/group.png"/>
-            <div class="div12">밥 세끼 먹기</div>
-            <div class="_1-min">1min</div>
-        </div>
-        <div class="frame-427318974">
-            <img class="group5" src="/group.png"/>
-            <div class="_5-km">런닝 5km</div>
-            <div class="_1-min">1min</div>
-        </div>
-        <div class="to-do-list-detail-bar">
-            <div class="container">
-                <div class="title2">ToDo List 상세</div>
-            </div>
-            <img class="vector-2002" src="vector-2001.svg"/>
-        </div>
-        <div class="search-box2">
-            <input class="textfield" type="text" placeholder="ToDo Card List Search">
-            <img class="ic-search" src="/search.png" alt="Search">
-        </div>
     </div>
-    <div class="_3">
-        <button class="button">
-            <div class="title6">등록</div>
-        </button>
-        <textarea class="input-field3" placeholder="댓글을 입력하세요"></textarea>
 
-        <div class="div2">댓글등록</div>
-        <div class="img-2">
-            <img class="lol" src="/lol.png"/>
-            <div class="_5">5</div>
-            <img class="surprised" src="/surprised.png"/>
-            <div class="_4">4</div>
-            <img class="vector" src="/vector.png"/>
-            <div class="_6">6</div>
+    <!-- 회고 바 -->
+    <div class="_3">
+        <div class="bar">
+            <div class="container">
+                <div class="title2">회고</div>
+            </div>
+            <img class="vector-200" src="vector-2000.svg"/>
         </div>
-        <div class="div3">
-            <div class="div4">엄준식 짱짱맨</div>
-        </div>
-        <div class="div5">
-            <div class="div4">엄준식 짱짱맨</div>
-        </div>
-        <div class="img-1">
-            <img class="lol" src="/lol.png"/>
-            <div class="_5">5</div>
-            <img class="surprised" src="/surprised.png"/>
-            <div class="_4">4</div>
-            <img class="vector2" src="/vector.png"/>
-            <div class="_6">6</div>
-        </div>
-        <div class="div6">댓글</div>
+
+        <!-- 회고 제목 및 내용 -->
+        <div class="div10">제목</div>
+        <div class="div9">오늘의 회고</div>
+        <div class="div8">공개</div>
+
         <div class="div7">
             <div class="to-do-list-a">
                 이번 주 ToDo List를 돌아보니, 많은 일을 완료할 수 있었지만 몇 가지
@@ -148,14 +151,39 @@
                 이번 회고를 통해 다음 주에 더 나은 계획을 세우고 싶습니다.
             </div>
         </div>
-        <div class="div8">공개</div>
-        <div9 class="div9">오늘의 회고</div9>
-        <div class="div10">제목</div>
-        <div class="bar">
-            <div class="container">
-                <div class="title2">회고</div>
-            </div>
-            <img class="vector-200" src="vector-2000.svg"/>
+
+        <!-- 댓글과 이모티콘 -->
+        <div class="div6">댓글</div>
+        <div class="div3">
+            <div class="div4">엄준식 짱짱맨</div>
         </div>
+        <div class="img-1">
+            <img class="lol" src="/lol.png"/>
+            <div class="_5">5</div>
+            <img class="surprised" src="/surprised.png"/>
+            <div class="_4">4</div>
+            <img class="vector2" src="/vector.png"/>
+            <div class="_6">6</div>
+        </div>
+        <div class="div5">
+            <div class="div4">엄준식 짱짱맨</div>
+        </div>
+        <div class="img-2">
+            <img class="lol" src="/lol.png"/>
+            <div class="_5">5</div>
+            <img class="surprised" src="/surprised.png"/>
+            <div class="_4">4</div>
+            <img class="vector" src="/vector.png"/>
+            <div class="_6">6</div>
+        </div>
+
+        <!-- 댓글 입력 필드 -->
+        <textarea class="input-field3" placeholder="댓글을 입력하세요"></textarea>
+        <div class="div2">댓글등록</div>
+
+        <!-- 등록 버튼 -->
+        <button class="button">
+            <div class="title6">등록</div>
+        </button>
     </div>
 </div>


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #61 #63 #64

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
remebrance 페이지
제목, 텍스트, 댓글 입력란 부분 어긋나 있는거 수정했습니다.

todo_list_detail 페이지

기존 좋아요, 싫어요, 하트 부분 흑백 이미지로 삽입되어 있었고, 클릭시 1씩 증가 안되었던거
흑백 이미지 -> 이모지로 변경하였고, 자바스크립트를 통해 이모지 클릭시 1씩 증가하도록 수정하였습니다.

댓글이 많아지면 페이지네이션 기능도 필요할 것 같아 기존 댓글란 하단과 댓글 작성란 사이에 해당 기능 추가하였습니다.

검색란 크기 조절하였습니다.

검색란 바로 상단에 "제목" 텍스트 추가하였습니다.

todo_list 페이지
todo_list 데이터가 추가되면 제목, 생성일 등 겹쳐 보이는거 수정하였고, 데이터가 많아지면 2페이지로 넘어갈 수 있도록 수정하였습니다.
데이터들이 페이지네이션과 겹치지 않게 수정하였습니다.

login_before 
불필요한 img 태그 삭제
분홍색 글씨 To-Do List 하단에 검색란, 버튼 좌우 간격 맞

### 스크린샷 (선택)
remembrance 페이지
![image](https://github.com/user-attachments/assets/30f1ed60-9e73-4f46-a544-2d934a388760)

todo_list_detail 페이지
![image](https://github.com/user-attachments/assets/0013e947-fe13-4111-9416-30ca9153e2cf)

todo_list 페이지
![image](https://github.com/user-attachments/assets/b3ecfaa1-614d-457d-ba82-dd61f7d4c54b)

login_before 페이지
![image](https://github.com/user-attachments/assets/86d11709-d48a-4e97-a0b2-212753efd54f)


## 💬리뷰 요구사항(선택)
- todo_list_detail 페이지에서 시간표 있는 부분 우측 상단에 검색란 부분이 위아래로 조금 넓고 좌우로 살짝 짧아 수정할 예정입니다.
- root url 페이지(login_after) 부분에 타임리프가 추가되면서 글씨, 이미지 간격이 달라진 부분이 있어 수정해야 할 듯 합니다.
![image](https://github.com/user-attachments/assets/4f0112c6-61d6-40db-a91c-8ff6392e5af2)